### PR TITLE
nyt api response too big for sentiment api

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -3,6 +3,6 @@ var router = express.Router();
 
 var nytController = require('../controllers/nytController');
 
-router.get('/nyt/articles', nytController.index);
+router.get('/nyt/articles', nytController.getArticles);
 
 module.exports = router;

--- a/controllers/nytController.js
+++ b/controllers/nytController.js
@@ -1,19 +1,53 @@
 var axios = require('axios');
+var sentiment = require('../controllers/sentiment');
+require('dotenv').load();
 
-function index(req, res) {
-  var key = process.env.NYT_KEY
+/*function index(req, res) {
+  var key = process.env.NYT_KEY;
+  console.log(key);
 
   axios.get(`https://api.nytimes.com/svc/archive/v1/2017/1.json?api-key=${key}`)
     .then(function (response) {
-      res.json(response.data.response.docs);
+      // res.json(response.data.response.docs);
+      sentiment.getSentiment(returnSentimentText(response.data.response.docs));
     })
     .catch(function (error) {
       console.log(error);
-      console.log('ERROR');
-      res.json(error);
+      console.log('ERROR!');
+      // res.json(error);
     })
+}*/
+
+function getArticles(year, month) {
+  (function callNYT(req, res) {
+    var key = process.env.NYT_KEY;
+    console.log(`nyt key: ${key}`);
+
+    axios.get(`https://api.nytimes.com/svc/archive/v1/${year}/${month}.json?api-key=${key}`)
+      .then(function (response) {
+        // res.json(response.data.response.docs);
+        console.log(response.data.response.docs);
+        sentiment.getSentiment(returnSentimentText(response.data.response.docs));
+      })
+      .catch(function (error) {
+        console.log(error);
+        console.log('ERROR!');
+        // res.json(error);
+      })
+  })();
 }
 
+function returnSentimentText(articles) {
+  var sentimentText = '';
+
+  for (var i = 0; i < articles.length; i++) {
+    sentimentText += (articles[i].headline.main + '. ');
+  }
+  return sentimentText;
+}
+
+getArticles('2017', '1');
+
 module.exports = {
-  index: index
+  getArticles: getArticles
 }

--- a/notes
+++ b/notes
@@ -1,6 +1,9 @@
 NYT response (incomplete list)
+`https://api.nytimes.com/svc/archive/v1/2017/1.json?api-key=${key}`
 
-$scope.articles[]
+var articles = response.data.response.docs;
+
+articles[]
 .headline
   .main
   .print_headline // longer headline?

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ const path = require('path');
 var bodyParser = require('body-parser');
 var routes = require('./config/routes');
 
-const sentiment = require('./sentiment.js');
+const sentiment = require('./controllers/sentiment.js');
 //const routers = require('./config/routes');
 
 var PORT = process.env.PORT || 3000;
@@ -16,7 +16,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
-// sentiment.getSentiment();
+// sentiment.getSentiment('I love you. I hate you.');
 
 app.listen(PORT, function() {
   console.log(`listening on port ${PORT}`);


### PR DESCRIPTION
Sentiment API crashes when passing concatenated headlines for the month of Jan '17. Since Jan isn't even halfway through, responses for any full month will likely be much larger.

May need to use a different sentiment API that can accept larger blocks of text, or need to pass smaller chunks into sentiment API and then average the resulting sentiment score of each chunk.

