### PR TITLE
New sentiment api

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -3,6 +3,6 @@ var router = express.Router();
 
 var nytController = require('../controllers/nytController');
 
-router.get('/nyt/articles', nytController.index);
+router.get('/nyt/articles', nytController.getArticles);
 
 module.exports = router;

--- a/controllers/nytController.js
+++ b/controllers/nytController.js
@@ -1,6 +1,55 @@
+require('dotenv').load();
 var axios = require('axios');
 var sentiment = require('../controllers/sentiment');
-require('dotenv').load();
+
+var sentObj =
+	{
+		"documents": [
+			{
+				"language": "en",
+				"id": "1",
+				"text": ""
+			}
+		]
+	};
+
+function getArticles(year, month) {
+  (function callNYT(req, res) {
+    var key = process.env.NYT_KEY;
+    console.log(`nyt key: ${key}`);
+
+    axios.get(`https://api.nytimes.com/svc/archive/v1/${year}/${month}.json?api-key=${key}`)
+      .then(function (response) {
+
+        sentObj.documents[0].text = returnSentimentText(response.data.response.docs);
+
+        sentiment.msSentiment(sentObj);
+
+        // Call to old sentiment API
+        // sentiment.getSentiment(returnSentimentText(response.data.response.docs));
+      })
+      .catch(function (error) {
+        console.log(error);
+        console.log('ERROR!');
+      })
+  })();
+}
+// getArticles('2017', '1');
+
+function returnSentimentText(articles) {
+  var sentimentText = '';
+
+  for (var i = 0; i < articles.length; i++) {
+    sentimentText += (articles[i].headline.main + '. ');
+  }
+  return sentimentText;
+}
+
+
+module.exports = {
+  getArticles: getArticles
+}
+
 
 /*function index(req, res) {
   var key = process.env.NYT_KEY;
@@ -17,37 +66,3 @@ require('dotenv').load();
       // res.json(error);
     })
 }*/
-
-function getArticles(year, month) {
-  (function callNYT(req, res) {
-    var key = process.env.NYT_KEY;
-    console.log(`nyt key: ${key}`);
-
-    axios.get(`https://api.nytimes.com/svc/archive/v1/${year}/${month}.json?api-key=${key}`)
-      .then(function (response) {
-        // res.json(response.data.response.docs);
-        console.log(response.data.response.docs);
-        sentiment.getSentiment(returnSentimentText(response.data.response.docs));
-      })
-      .catch(function (error) {
-        console.log(error);
-        console.log('ERROR!');
-        // res.json(error);
-      })
-  })();
-}
-
-function returnSentimentText(articles) {
-  var sentimentText = '';
-
-  for (var i = 0; i < articles.length; i++) {
-    sentimentText += (articles[i].headline.main + '. ');
-  }
-  return sentimentText;
-}
-
-getArticles('2017', '1');
-
-module.exports = {
-  getArticles: getArticles
-}

--- a/controllers/nytController.js
+++ b/controllers/nytController.js
@@ -1,19 +1,53 @@
 var axios = require('axios');
+var sentiment = require('../controllers/sentiment');
+require('dotenv').load();
 
-function index(req, res) {
-  var key = process.env.NYT_KEY
+/*function index(req, res) {
+  var key = process.env.NYT_KEY;
+  console.log(key);
 
   axios.get(`https://api.nytimes.com/svc/archive/v1/2017/1.json?api-key=${key}`)
     .then(function (response) {
-      res.json(response.data.response.docs);
+      // res.json(response.data.response.docs);
+      sentiment.getSentiment(returnSentimentText(response.data.response.docs));
     })
     .catch(function (error) {
       console.log(error);
-      console.log('ERROR');
-      res.json(error);
+      console.log('ERROR!');
+      // res.json(error);
     })
+}*/
+
+function getArticles(year, month) {
+  (function callNYT(req, res) {
+    var key = process.env.NYT_KEY;
+    console.log(`nyt key: ${key}`);
+
+    axios.get(`https://api.nytimes.com/svc/archive/v1/${year}/${month}.json?api-key=${key}`)
+      .then(function (response) {
+        // res.json(response.data.response.docs);
+        console.log(response.data.response.docs);
+        sentiment.getSentiment(returnSentimentText(response.data.response.docs));
+      })
+      .catch(function (error) {
+        console.log(error);
+        console.log('ERROR!');
+        // res.json(error);
+      })
+  })();
 }
 
+function returnSentimentText(articles) {
+  var sentimentText = '';
+
+  for (var i = 0; i < articles.length; i++) {
+    sentimentText += (articles[i].headline.main + '. ');
+  }
+  return sentimentText;
+}
+
+getArticles('2017', '1');
+
 module.exports = {
-  index: index
+  getArticles: getArticles
 }

--- a/controllers/sentiment.js
+++ b/controllers/sentiment.js
@@ -1,19 +1,55 @@
+require('dotenv').load();
 var unirest = require('unirest');
+var axios = require('axios');
 
 var text = text;
 
 var getSentiment = (text) => {
-    unirest.post("https://twinword-sentiment-analysis.p.mashape.com/analyze/")
-        .header("X-Mashape-Key", "XWwI1lRtyEmsh1g9SDGRVs5BlBChp1LZoHCjsnjuhLqJTLgvws")
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .header("Accept", "application/json")
-        .send(`text=${text}`)
-        .end((result) => {
-            console.log(result.body);
+	unirest.post("https://twinword-sentiment-analysis.p.mashape.com/analyze/")
+		.header("X-Mashape-Key", "XWwI1lRtyEmsh1g9SDGRVs5BlBChp1LZoHCjsnjuhLqJTLgvws")
+		.header("Content-Type", "application/x-www-form-urlencoded")
+		.header("Accept", "application/json")
+		.send(`text=${text}`)
+		.end((result) => {
+			console.log(result.body);
 
-        });
+		});
 }
 
+var msSentiment = (obj, req, res) => {
+	var apikey = process.env.SENTIMENT;
+	console.log(apikey);
+	var config = {
+		headers: {
+			'Ocp-Apim-Subscription-Key': apikey,
+			'Content-Type': 'application/json',
+			'Accept': 'application/json'
+		}
+	}
+	axios.post('https://westus.api.cognitive.microsoft.com/text/analytics/v2.0/sentiment', obj, config)
+		.then(function (response) {
+			console.log(response.data);
+		})
+		.catch(function (error) {
+			console.log(error);
+		})
+}
+
+/*msSentiment(
+	{
+		"documents": [
+			{
+			"language": "en",
+			"id": "1",
+			"text": "This is effin awesome!"
+			}
+		]
+	}
+)*/
+
+// MS Sentiment POST object template
+
 module.exports = {
-  getSentiment
+	getSentiment,
+	msSentiment
 }

--- a/notes
+++ b/notes
@@ -1,6 +1,9 @@
 NYT response (incomplete list)
+`https://api.nytimes.com/svc/archive/v1/2017/1.json?api-key=${key}`
 
-$scope.articles[]
+var articles = response.data.response.docs;
+
+articles[]
 .headline
   .main
   .print_headline // longer headline?

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ const path = require('path');
 var bodyParser = require('body-parser');
 var routes = require('./config/routes');
 
-const sentiment = require('./sentiment.js');
+const sentiment = require('./controllers/sentiment.js');
 //const routers = require('./config/routes');
 
 var PORT = process.env.PORT || 3000;
@@ -16,7 +16,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
-// sentiment.getSentiment();
+// sentiment.getSentiment('I love you. I hate you.');
 
 app.listen(PORT, function() {
   console.log(`listening on port ${PORT}`);


### PR DESCRIPTION
Implemented Microsoft cognitive services' text-analytics API for sentiment results. Reached the size limit for a single object, but can accept 1,000 JSON objects in a single POST

![capture](https://cloud.githubusercontent.com/assets/22664395/21921019/e650ce56-d919-11e6-856d-1d2afc452659.PNG)
